### PR TITLE
Object pooling upgrade

### DIFF
--- a/lib/entity-component-system-test.js
+++ b/lib/entity-component-system-test.js
@@ -23,7 +23,7 @@ test("run with each system and array of entities calls system with each entity",
 
 	var entities = new Pool();
 	var id = entities.create();
-	entities.set(id, "name", "jimmy");
+	entities.setComponent(id, "name", "jimmy");
 
 	var ecs = new ECS();
 	var done = function(arg, arg2) {

--- a/lib/entity-pool-test.js
+++ b/lib/entity-pool-test.js
@@ -90,14 +90,10 @@ test("addComponent resets the existing component", function(t) {
 	var pool = new EntityPool();
 	var id = pool.create();
 
-	function Info() {
-		this.location = "Louisville";
-	}
-	Info.prototype.reset = function() {
-		this.location = "Louisville";
-	};
-	pool.registerComponent("info", function () {
-		return new Info();
+	pool.registerComponent("info", function() {
+		return { location: "Louisville" };
+	}, function(c) {
+		c.location = "Louisville";
 	});
 
 	pool.addComponent(id, "info").location = "Pittsburgh";
@@ -214,14 +210,10 @@ test("removeComponent resets the component", function(t) {
 	var pool = new EntityPool();
 	var id = pool.create();
 
-	function Info() {
-		this.location = "Louisville";
-	}
-	Info.prototype.reset = function() {
-		this.location = "Louisville";
-	};
 	pool.registerComponent("info", function () {
-		return new Info();
+		return { location: "Louisville" };
+	}, function(c) {
+		c.location = "Louisville";
 	});
 
 	var value = pool.addComponent(id, "info");

--- a/lib/entity-pool-test.js
+++ b/lib/entity-pool-test.js
@@ -28,7 +28,7 @@ test("destroy deletes a whole entity", function(t) {
 		var pool = new EntityPool();
 		var id = pool.create();
 		pool.destroy(id);
-		pool.get(id, "id");
+		pool.getComponent(id, "id");
 	});
 });
 
@@ -37,7 +37,7 @@ test("get with id returns the id", function(t) {
 
 	var pool = new EntityPool();
 	var id = pool.create();
-	var result = pool.get(id, "id");
+	var result = pool.getComponent(id, "id");
 	t.equal(result, id);
 });
 
@@ -46,8 +46,8 @@ test("set with component can be fetched with get", function(t) {
 
 	var pool = new EntityPool();
 	var id = pool.create();
-	pool.set(id, "name", "jimmy");
-	var name = pool.get(id, "name");
+	pool.setComponent(id, "name", "jimmy");
+	var name = pool.getComponent(id, "name");
 
 	t.equal(name, "jimmy");
 });
@@ -56,8 +56,8 @@ test("set with component can be fetched with get", function(t) {
 
 	var pool = new EntityPool();
 	var id = pool.create();
-	pool.set(id, "name", "jimmy");
-	var name = pool.get(id, "name");
+	pool.setComponent(id, "name", "jimmy");
+	var name = pool.getComponent(id, "name");
 
 	t.equal(name, "jimmy");
 });
@@ -66,8 +66,8 @@ test("set with same component twice isn't in search twice", function(t) {
 
 	var pool = new EntityPool();
 	var id = pool.create();
-	pool.set(id, "name", "jimmy");
-	pool.set(id, "name", "jimmy");
+	pool.setComponent(id, "name", "jimmy");
+	pool.setComponent(id, "name", "jimmy");
 	var results = pool.find("name");
 
 	t.equal(results.length, 1);
@@ -77,8 +77,8 @@ test("set with existing component to undefined removes from search", function(t)
 
 	var pool = new EntityPool();
 	var id = pool.create();
-	pool.set(id, "name", "jimmy");
-	pool.set(id, "name", undefined);
+	pool.setComponent(id, "name", "jimmy");
+	pool.setComponent(id, "name", undefined);
 	var results = pool.find("name");
 
 	t.equal(results.length, 0);
@@ -90,9 +90,9 @@ test("remove with component makes it unable to be fetched", function(t) {
 
 	var pool = new EntityPool();
 	var id = pool.create();
-	pool.set(id, "name", "jimmy");
-	pool.remove(id, "name");
-	var name = pool.get(id, "name");
+	pool.setComponent(id, "name", "jimmy");
+	pool.removeComponent(id, "name");
+	var name = pool.getComponent(id, "name");
 
 	t.equal(name, undefined);
 });
@@ -102,7 +102,7 @@ test("find with no matching components returns empty list", function(t) {
 
 	var pool = new EntityPool();
 	var id = pool.create();
-	pool.set(id, "name", "jimmy");
+	pool.setComponent(id, "name", "jimmy");
 	var results = pool.find("does-not-exist");
 
 	t.deepEqual(results, []);
@@ -113,9 +113,9 @@ test("find with matching component returns list with entities", function(t) {
 
 	var pool = new EntityPool();
 	var id = pool.create();
-	pool.set(id, "name", "jimmy");
+	pool.setComponent(id, "name", "jimmy");
 	var id2 = pool.create();
-	pool.set(id2, "name", "amy");
+	pool.setComponent(id2, "name", "amy");
 	var results = pool.find("name");
 
 	t.deepEqual(results, [id, id2]);
@@ -126,8 +126,8 @@ test("find with deleted component returns empty list", function(t) {
 
 	var pool = new EntityPool();
 	var id = pool.create();
-	pool.set(id, "name", "jimmy");
-	pool.remove(id, "name");
+	pool.setComponent(id, "name", "jimmy");
+	pool.removeComponent(id, "name");
 	var results = pool.find("name");
 
 	t.deepEqual(results, []);
@@ -138,8 +138,8 @@ test("registerSearch with two components and entities already added returns enti
 
 	var pool = new EntityPool();
 	var id = pool.create();
-	pool.set(id, "name", "jimmy");
-	pool.set(id, "age", 8);
+	pool.setComponent(id, "name", "jimmy");
+	pool.setComponent(id, "age", 8);
 	pool.registerSearch("peopleWithAge", ["name", "age"]);
 	var results = pool.find("peopleWithAge");
 
@@ -152,8 +152,8 @@ test("registerSearch with two components and entities added after returns entiti
 	var pool = new EntityPool();
 	var id = pool.create();
 	pool.registerSearch("peopleWithAge", ["name", "age"]);
-	pool.set(id, "name", "jimmy");
-	pool.set(id, "age", 8);
+	pool.setComponent(id, "name", "jimmy");
+	pool.setComponent(id, "age", 8);
 	var results = pool.find("peopleWithAge");
 
 	t.deepEqual(results, [id]);
@@ -175,9 +175,9 @@ test("remove removes an entity from a complex search", function(t) {
 	var pool = new EntityPool();
 	var id = pool.create();
 	pool.registerSearch("peopleWithAge", ["name", "age"]);
-	pool.set(id, "name", "jimmy");
-	pool.set(id, "age", 8);
-	pool.remove(id, "age");
+	pool.setComponent(id, "name", "jimmy");
+	pool.setComponent(id, "age", 8);
+	pool.removeComponent(id, "age");
 	var results = pool.find("peopleWithAge");
 
 	t.deepEqual(results, []);
@@ -188,7 +188,7 @@ test("load creates an entity", function(t) {
 
 	var pool = new EntityPool();
 	pool.load([{ id: 1, name: "jimmy" }]);
-	var name = pool.get(1, "name");
+	var name = pool.getComponent(1, "name");
 
 	t.deepEqual(name, "jimmy");
 });
@@ -208,7 +208,7 @@ test("save returns entities", function(t) {
 
 	var pool = new EntityPool();
 	var id = pool.create();
-	pool.set(id, "name", "jimmy");
+	pool.setComponent(id, "name", "jimmy");
 	var output = pool.save();
 
 	t.deepEqual(output, [{ id: id, name: "jimmy"}]);
@@ -227,7 +227,7 @@ test("onAddComponent with callback is called after set", function(t) {
 	pool.onAddComponent("name", callback);
 	pool.onAddComponent("name", callback);
 
-	pool.set(id, "name", "jimmy");
+	pool.setComponent(id, "name", "jimmy");
 });
 
 test("onAddComponent with callback is not called on modifying existing component", function(t) {
@@ -242,8 +242,8 @@ test("onAddComponent with callback is not called on modifying existing component
 	}
 	pool.onAddComponent("name", callback);
 
-	pool.set(id, "name", "jimmy");
-	pool.set(id, "name", "salazar");
+	pool.setComponent(id, "name", "jimmy");
+	pool.setComponent(id, "name", "salazar");
 });
 
 test("onAddComponent with callback is not called until all data is loaded", function(t) {
@@ -251,7 +251,7 @@ test("onAddComponent with callback is not called until all data is loaded", func
 
 	var pool = new EntityPool();
 	function callback(entity) {
-		t.equal(pool.get(entity, "age"), 28);
+		t.equal(pool.getComponent(entity, "age"), 28);
 	}
 	pool.onAddComponent("name", callback);
 	pool.load([{ id: 1, name: "jimmy", age: 28 }]);
@@ -261,7 +261,7 @@ test("onRemoveComponent with callback is called on removing component", function
 
 	var pool = new EntityPool();
 	var id = pool.create();
-	pool.set(id, "name", "jimmy");
+	pool.setComponent(id, "name", "jimmy");
 	function callback(entity, component, value) {
 		t.equal(entity, id);
 		t.equal(component, "name");
@@ -269,7 +269,7 @@ test("onRemoveComponent with callback is called on removing component", function
 	}
 	pool.onRemoveComponent("name", callback);
 
-	pool.remove(id, "name");
+	pool.removeComponent(id, "name");
 });
 
 test("onRemoveComponent with callback isn't called on removing nonexistant component", function(t) {
@@ -277,7 +277,7 @@ test("onRemoveComponent with callback isn't called on removing nonexistant compo
 
 	var pool = new EntityPool();
 	var id = pool.create();
-	pool.set(id, "name", "jimmy");
+	pool.setComponent(id, "name", "jimmy");
 	function callback(entity, component, value) {
 		t.equal(entity, id);
 		t.equal(component, "name");
@@ -285,6 +285,6 @@ test("onRemoveComponent with callback isn't called on removing nonexistant compo
 	}
 	pool.onRemoveComponent("name", callback);
 
-	pool.remove(id, "name");
-	pool.remove(id, "name");
+	pool.removeComponent(id, "name");
+	pool.removeComponent(id, "name");
 });

--- a/lib/entity-pool-test.js
+++ b/lib/entity-pool-test.js
@@ -45,12 +45,12 @@ test("entity ids get reused", function(t) {
 	t.plan(1);
 
 	var pool = new EntityPool();
-	var idA = pool.create();
-	var idB = pool.create();
-	pool.destroy(idA);
-	var idC = pool.create();
+	var a = pool.create();
+	pool.create();
+	pool.destroy(a);
+	var b = pool.create();
 
-	t.equal(idA, idC);
+	t.equal(a, b);
 });
 
 test("addComponent can get fetched with getComponent", function(t) {
@@ -60,10 +60,10 @@ test("addComponent can get fetched with getComponent", function(t) {
 	var id = pool.create();
 	pool.registerComponent("prop", function () {
 		return {};
-	})
+	});
 
 	var a = pool.addComponent(id, "prop");
-	var b = pool.getComponent(id, "prop")
+	var b = pool.getComponent(id, "prop");
 
 	t.equal(a, b);
 });
@@ -75,7 +75,7 @@ test("if a component already exists on an entity, addComponent returns it UNLESS
 	pool.setComponent(id, "prop", "hello world");
 	pool.registerComponent("prop", function () {
 		return {};
-	})
+	});
 
 	var a = pool.getComponent(id, "prop");
 	var b = pool.addComponent(id, "prop");
@@ -114,7 +114,7 @@ test("addComponent returns a component matching the provided factory function", 
 	var id = pool.create();
 	pool.registerComponent("info", function () {
 		return { location: "Louisville" };
-	})
+	});
 
 	var value = pool.addComponent(id, "info");
 
@@ -127,14 +127,14 @@ test("updating the value returned by addComponent persists in EntityPool", funct
 	var id = pool.create();
 	pool.registerComponent("info", function () {
 		return { location: "Louisville" };
-	})
+	});
 
 	var a = pool.addComponent(id, "info");
 	var locationA = a.location = "Pittsburgh";
 	var b = pool.getComponent(id, "info");
 	var locationB = b.location;
 
-	t.equal(a, b);
+	t.equal(locationA, locationB);
 });
 
 test("setComponent with component can be fetched with getComponent", function(t) {
@@ -188,8 +188,8 @@ test("setComponent fails if already existing value is not primitive", function(t
 	var id = pool.create();
 	pool.registerComponent("prop", function () {
 		return {};
-	})
-	var a = pool.addComponent(id, "prop");
+	});
+	pool.addComponent(id, "prop");
 
 	t.throws(function() {
 		pool.setComponent(id, "prop", "hello world");

--- a/lib/entity-pool-test.js
+++ b/lib/entity-pool-test.js
@@ -53,16 +53,67 @@ test("entity ids get reused", function(t) {
 	t.equal(idA, idC);
 });
 
-test("setComponent with component can be fetched with getComponent", function(t) {
+test("addComponent can get fetched with getComponent", function(t) {
 	t.plan(1);
 
 	var pool = new EntityPool();
 	var id = pool.create();
-	pool.setComponent(id, "name", "jimmy");
-	var name = pool.getComponent(id, "name");
+	pool.registerComponent("prop", function () {
+		return {};
+	})
 
-	t.equal(name, "jimmy");
+	var a = pool.addComponent(id, "prop");
+	var b = pool.getComponent(id, "prop")
+
+	t.equal(a, b);
 });
+test("if a component already exists on an entity, addComponent returns it UNLESS it's primitive", function(t) {
+	t.plan(2);
+
+	var pool = new EntityPool();
+	var id = pool.create();
+	pool.setComponent(id, "prop", "hello world");
+	pool.registerComponent("prop", function () {
+		return {};
+	})
+
+	var a = pool.getComponent(id, "prop");
+	var b = pool.addComponent(id, "prop");
+	var c = pool.addComponent(id, "prop");
+
+	t.equal(b, c, "returns old component if old component is object");
+	t.notEqual(a, b, "returns new component if old component is primitive");
+});
+test("addComponent returns a component matching the provided factory function", function(t) {
+	t.plan(1);
+
+	var pool = new EntityPool();
+	var id = pool.create();
+	pool.registerComponent("info", function () {
+		return { location: "Louisville" };
+	})
+
+	var value = pool.addComponent(id, "info");
+
+	t.equal(value.location, "Louisville");
+});
+test("updating the value returned by addComponent persists in EntityPool", function(t) {
+	t.plan(1);
+
+	var pool = new EntityPool();
+	var id = pool.create();
+	pool.registerComponent("info", function () {
+		return { location: "Louisville" };
+	})
+
+	var a = pool.addComponent(id, "info");
+	var locationA = a.location = "Pittsburgh";
+	var b = pool.getComponent(id, "info");
+	var locationB = b.location;
+
+	t.equal(a, b);
+});
+
 test("setComponent with component can be fetched with getComponent", function(t) {
 	t.plan(1);
 
@@ -94,6 +145,32 @@ test("setComponent with existing component to undefined removes from search", fu
 	var results = pool.find("name");
 
 	t.equal(results.length, 0);
+});
+test("setComponent fails if passed value is not primitive", function(t) {
+	t.plan(1);
+
+	var pool = new EntityPool();
+	var id = pool.create();
+
+	t.throws(function() {
+		pool.setComponent(id, "info", {
+			location: "Louisville"
+		});
+	}, TypeError, "should throw TypeError");
+});
+test("setComponent fails if already existing value is not primitive", function(t) {
+	t.plan(1);
+
+	var pool = new EntityPool();
+	var id = pool.create();
+	pool.registerComponent("prop", function () {
+		return {};
+	})
+	var a = pool.addComponent(id, "prop");
+
+	t.throws(function() {
+		pool.setComponent(id, "prop", "hello world");
+	});
 });
 
 

--- a/lib/entity-pool-test.js
+++ b/lib/entity-pool-test.js
@@ -32,7 +32,7 @@ test("destroy deletes a whole entity", function(t) {
 	});
 });
 
-test("get with id returns the id", function(t) {
+test("getComponent with id returns the id", function(t) {
 	t.plan(1);
 
 	var pool = new EntityPool();
@@ -53,7 +53,7 @@ test("entity ids get reused", function(t) {
 	t.equal(idA, idC);
 });
 
-test("set with component can be fetched with get", function(t) {
+test("setComponent with component can be fetched with getComponent", function(t) {
 	t.plan(1);
 
 	var pool = new EntityPool();
@@ -63,7 +63,7 @@ test("set with component can be fetched with get", function(t) {
 
 	t.equal(name, "jimmy");
 });
-test("set with component can be fetched with get", function(t) {
+test("setComponent with component can be fetched with getComponent", function(t) {
 	t.plan(1);
 
 	var pool = new EntityPool();
@@ -73,7 +73,7 @@ test("set with component can be fetched with get", function(t) {
 
 	t.equal(name, "jimmy");
 });
-test("set with same component twice isn't in search twice", function(t) {
+test("setComponent with same component twice isn't in search twice", function(t) {
 	t.plan(1);
 
 	var pool = new EntityPool();
@@ -84,7 +84,7 @@ test("set with same component twice isn't in search twice", function(t) {
 
 	t.equal(results.length, 1);
 });
-test("set with existing component to undefined removes from search", function(t) {
+test("setComponent with existing component to undefined removes from search", function(t) {
 	t.plan(1);
 
 	var pool = new EntityPool();
@@ -97,7 +97,7 @@ test("set with existing component to undefined removes from search", function(t)
 });
 
 
-test("remove with component makes it unable to be fetched", function(t) {
+test("removeComponent with component makes it unable to be fetched", function(t) {
 	t.plan(1);
 
 	var pool = new EntityPool();
@@ -181,7 +181,7 @@ test("registerSearch twice with same name throws", function(t) {
 	});
 });
 
-test("remove removes an entity from a complex search", function(t) {
+test("removeComponent removes an entity from a complex search", function(t) {
 	t.plan(1);
 
 	var pool = new EntityPool();

--- a/lib/entity-pool-test.js
+++ b/lib/entity-pool-test.js
@@ -41,6 +41,18 @@ test("get with id returns the id", function(t) {
 	t.equal(result, id);
 });
 
+test("entity ids get reused", function(t) {
+	t.plan(1);
+
+	var pool = new EntityPool();
+	var idA = pool.create();
+	var idB = pool.create();
+	pool.destroy(idA);
+	var idC = pool.create();
+
+	t.equal(idA, idC);
+});
+
 test("set with component can be fetched with get", function(t) {
 	t.plan(1);
 

--- a/lib/entity-pool-test.js
+++ b/lib/entity-pool-test.js
@@ -84,6 +84,29 @@ test("if a component already exists on an entity, addComponent returns it UNLESS
 	t.equal(b, c, "returns old component if old component is object");
 	t.notEqual(a, b, "returns new component if old component is primitive");
 });
+test("addComponent resets the existing component", function(t) {
+	t.plan(2);
+
+	var pool = new EntityPool();
+	var id = pool.create();
+
+	function Info() {
+		this.location = "Louisville";
+	}
+	Info.prototype.reset = function() {
+		this.location = "Louisville";
+	};
+	pool.registerComponent("info", function () {
+		return new Info();
+	});
+
+	pool.addComponent(id, "info").location = "Pittsburgh";
+	var a = pool.getComponent(id, "info").location;
+	var b = pool.addComponent(id, "info").location;
+
+	t.notEqual(a, b);
+	t.equal(b, "Louisville", "factory reset is run on addComponent if component exists");
+});
 test("addComponent returns a component matching the provided factory function", function(t) {
 	t.plan(1);
 
@@ -184,6 +207,30 @@ test("removeComponent with component makes it unable to be fetched", function(t)
 	var name = pool.getComponent(id, "name");
 
 	t.equal(name, undefined);
+});
+test("removeComponent resets the component", function(t) {
+	t.plan(2);
+
+	var pool = new EntityPool();
+	var id = pool.create();
+
+	function Info() {
+		this.location = "Louisville";
+	}
+	Info.prototype.reset = function() {
+		this.location = "Louisville";
+	};
+	pool.registerComponent("info", function () {
+		return new Info();
+	});
+
+	var value = pool.addComponent(id, "info");
+	var a = value.location = "Pittsburgh";
+	pool.removeComponent(id, "info");
+	var b = value.location;
+
+	t.notEqual(a, b);
+	t.equal(b, "Louisville", "factory reset is run on removeComponent");
 });
 
 test("find with no matching components returns empty list", function(t) {

--- a/lib/entity-pool.js
+++ b/lib/entity-pool.js
@@ -9,6 +9,7 @@ function EntityPool() {
 		return { id: this.nextId++ };
 	}.bind(this));
 	this._componentPools = {};
+	this._resetFunctions = {};
 	this.searchToComponents = {};
 	this.componentToSearches = {};
 	this.searchResults = {};
@@ -30,23 +31,30 @@ EntityPool.prototype.destroy = function(id) {
 	delete this._entities[id];
 	this._entityPool.free(entity);
 };
-EntityPool.prototype.registerComponent = function(component, factory, size) {
+EntityPool.prototype.registerComponent = function(component, factory, reset, size) {
 	this._componentPools[component] = new ObjectPool(factory, size);
+	this._resetFunctions[component] = reset;
+};
+EntityPool.prototype._resetComponent = function(id, component) {
+	var reset = this._resetFunctions[component];
+	if (typeof reset === "function") {
+		reset(this._entities[id][component]);
+	}
 };
 EntityPool.prototype.getComponent = function(id, component) {
 	return this._entities[id][component];
 };
 EntityPool.prototype.removeComponent = function(id, component) {
-	if (this._entities[id][component] === undefined) {
+	var oldValue = this._entities[id][component];
+	if (oldValue === undefined) {
 		return;
 	}
 
-	var oldValue = this._entities[id][component];
-	delete this._entities[id][component];
 	if (!isPrimitive(oldValue)) {
-		resetComponent(oldValue);
+		this._resetComponent(id, component);
 		this._componentPools[component].free(oldValue);
 	}
+	delete this._entities[id][component];
 
 	for (var i = 0; i < this.componentToSearches[component].length; i++) {
 		var search = this.componentToSearches[component][i];
@@ -65,7 +73,7 @@ EntityPool.prototype.addComponent = function(id, component) {
 
 	var predefinedValue = this._entities[id][component];
 	if (predefinedValue && !isPrimitive(predefinedValue)) {
-		resetComponent(predefinedValue);
+		this._resetComponent(id, component);
 		return predefinedValue;
 	}
 
@@ -221,12 +229,6 @@ function removeFromArray(array, item) {
 		array.splice(i, 1);
 	}
 	return array;
-}
-
-function resetComponent(value) {
-	if (typeof value.reset === "function") {
-		value.reset();
-	}
 }
 
 function entityId(entity) {

--- a/lib/entity-pool.js
+++ b/lib/entity-pool.js
@@ -120,7 +120,7 @@ EntityPool.prototype._setComponentValue = function(id, component, value) {
 	if (typeof existingValue === "undefined") {
 		this.fireCallback("add", id, component, value);
 	}
-}
+};
 // private
 EntityPool.prototype.addCallback = function(type, component, callback) {
 	this.callbacks[type] = this.callbacks[type] || {};
@@ -224,7 +224,7 @@ function removeFromArray(array, item) {
 }
 
 function resetComponent(value) {
-	if (typeof value.reset === 'function') {
+	if (typeof value.reset === "function") {
 		value.reset();
 	}
 }

--- a/lib/entity-pool.js
+++ b/lib/entity-pool.js
@@ -1,17 +1,23 @@
 "use strict";
 
+var ObjectPool = require("./object-pool");
+
 function EntityPool() {
-	this.nextId = 0;
 	this._entities = {};
+	this.nextId = 0;
+	this._entityPool = new ObjectPool(function() {
+		return { id: this.nextId++ };
+	}.bind(this));
+	this._componentPools = {};
 	this.searchToComponents = {};
 	this.componentToSearches = {};
 	this.searchResults = {};
 	this.callbacks = {};
 }
 EntityPool.prototype.create = function() {
-	var id = this.nextId++;
-	this._entities[id] = { id: id };
-	return id;
+	var entity = this._entityPool.alloc();
+	this._entities[entity.id] = entity;
+	return entity.id;
 };
 EntityPool.prototype.destroy = function(id) {
 	var entity = this._entities[id];
@@ -19,34 +25,79 @@ EntityPool.prototype.destroy = function(id) {
 		if (component === "id") {
 			return;
 		}
-		this.remove(id, component);
+		this.removeComponent(id, component);
 	}.bind(this));
 	delete this._entities[id];
 };
-EntityPool.prototype.get = function(id, component) {
+EntityPool.prototype.registerComponent = function(component, factory, size) {
+	this._componentPools[component] = new ObjectPool(factory, size);
+};
+EntityPool.prototype.getComponent = function(id, component) {
 	return this._entities[id][component];
 };
-EntityPool.prototype.remove = function(id, component) {
+EntityPool.prototype.removeComponent = function(id, component) {
 	if (this._entities[id][component] === undefined) {
 		return;
 	}
+
 	var oldValue = this._entities[id][component];
 	delete this._entities[id][component];
+	if (!isPrimitive(oldValue)) {
+		resetComponent(oldValue);
+		this._componentPools[component].free(oldValue);
+	}
+
 	for (var i = 0; i < this.componentToSearches[component].length; i++) {
 		var search = this.componentToSearches[component][i];
 		removeFromArray(this.searchResults[search], id);
 	}
 	this.fireCallback("remove", id, component, oldValue);
 };
-EntityPool.prototype.set = function(id, component, value) {
-	if (value === undefined) {
-		return this.remove(id, component);
+EntityPool.prototype.addComponent = function(id, component) {
+	if (!this._componentPools[component]) {
+		throw new Error(
+			"You can't call EntityPool.prototype.addComponent(id, component) " +
+			"for a component name that hasn't been registered with " +
+			"EntityPool.prototype.registerComponent(component, factory[, size])."
+		);
 	}
-	var wasUndefined = this._entities[id][component] === undefined;
-	this._entities[id][component] = value;
-	if (!wasUndefined) {
+
+	var predefinedValue = this._entities[id][component];
+	if (predefinedValue) {
+		resetComponent(predefinedValue);
+		return predefinedValue;
+	}
+
+	var value = this._componentPools[component].alloc();
+	this._setComponentValue(id, component, value);
+
+	return value;
+};
+EntityPool.prototype.setComponent = function(id, component, value) {
+	if (!isPrimitive(value)) {
+		throw new Error(
+			"You can't call EntityPool.prototype.setComponent(id, component, value) with " +
+			"a value that isn't of a primitive type (i.e. null, undefined, boolean, " +
+			"number, string, or symbol). For objects or arrays, use " +
+			"EntityPool.prototype.addComponent(id, component) and modify " +
+			"the result it returns."
+		);
+	}
+
+	if (typeof value === "undefined" ) {
+		this.removeComponent(id, component);
+	} else {
+		this._setComponentValue(id, component, value);
+	}
+};
+// private
+EntityPool.prototype._setComponentValue = function(id, component, value) {
+	var existingValue = this._entities[id][component];
+	if (typeof existingValue !== "undefined" && existingValue === value) {
 		return;
 	}
+
+	this._entities[id][component] = value;
 	if (this.searchToComponents[component] === undefined) {
 		this.mapSearch(component, [component]);
 	}
@@ -56,8 +107,11 @@ EntityPool.prototype.set = function(id, component, value) {
 			this.searchResults[search].push(id);
 		}
 	}
-	this.fireCallback("add", id, component, value);
-};
+	
+	if (typeof existingValue === "undefined") {
+		this.fireCallback("add", id, component, value);
+	}
+}
 // private
 EntityPool.prototype.addCallback = function(type, component, callback) {
 	this.callbacks[type] = this.callbacks[type] || {};
@@ -125,12 +179,24 @@ EntityPool.prototype.load = function(entities) {
 	this.callbackQueue = [];
 	entities.forEach(function(entity) {
 		var id = entity.id;
-		this._entities[id] = { id: id };
+		var allocatedEntity = this._entityPool.alloc();
+		allocatedEntity.id = id;
+		this._entities[id] = allocatedEntity;
 		if (this.nextId <= id) {
 			this.nextId = id + 1;
 		}
 		Object.keys(entity).forEach(function(component) {
-			this.set(id, component, entity[component]);
+			if (component === "id") {
+				return;
+			}
+			var valueToLoad = entity[component];
+			if (isPrimitive(valueToLoad)) {
+				return this.setComponent(id, component, valueToLoad);
+			}
+			var newComponentObject = this.addComponent(id, component);
+			Object.keys(valueToLoad).forEach(function(key) {
+		    newComponentObject[key] = valueToLoad[key];
+		  });
 		}.bind(this));
 	}.bind(this));
 	this.fireQueuedCallbacks();
@@ -148,6 +214,12 @@ function removeFromArray(array, item) {
 	return array;
 }
 
+function resetComponent(value) {
+	if (typeof value.reset === 'function') {
+		value.reset();
+	}
+}
+
 function entityId(entity) {
 	return entity.id;
 }
@@ -159,6 +231,14 @@ function objectValues(obj) {
 	return Object.keys(obj).map(function(key) {
 		return obj[key];
 	});
+}
+
+/* returns true if the value is a primitive
+ * type a.k.a. null, undefined, boolean,
+ * number, string, or symbol.
+ */
+function isPrimitive(value) {
+	return typeof value !== "object" || value === null;
 }
 
 module.exports = EntityPool;

--- a/lib/entity-pool.js
+++ b/lib/entity-pool.js
@@ -55,7 +55,7 @@ EntityPool.prototype.removeComponent = function(id, component) {
 };
 EntityPool.prototype.addComponent = function(id, component) {
 	if (!this._componentPools[component]) {
-		throw new Error(
+		throw new NoSuchComponentPoolException(
 			"You can't call EntityPool.prototype.addComponent(id, component) " +
 			"for a component name that hasn't been registered with " +
 			"EntityPool.prototype.registerComponent(component, factory[, size])."
@@ -75,7 +75,7 @@ EntityPool.prototype.addComponent = function(id, component) {
 };
 EntityPool.prototype.setComponent = function(id, component, value) {
 	if (!isPrimitive(value)) {
-		throw new Error(
+		throw new TypeError(
 			"You can't call EntityPool.prototype.setComponent(id, component, value) with " +
 			"a value that isn't of a primitive type (i.e. null, undefined, boolean, " +
 			"number, string, or symbol). For objects or arrays, use " +
@@ -86,7 +86,7 @@ EntityPool.prototype.setComponent = function(id, component, value) {
 
 	if (!isPrimitive(this._entities[id][component])) {
 		throw new Error(
-			"You can't set a non-primitive type component to a  primitive value. " +
+			"You can't set a non-primitive type component to a primitive value. " +
 			"If you must do this, remove the existing component first with " +
 			"EntityPool.prototype.removeComponent(id, component)."
 		);
@@ -247,6 +247,10 @@ function objectValues(obj) {
  */
 function isPrimitive(value) {
 	return typeof value !== "object" || value === null;
+}
+
+function NoSuchComponentPoolException (message) {
+	this.message = message;
 }
 
 module.exports = EntityPool;

--- a/lib/entity-pool.js
+++ b/lib/entity-pool.js
@@ -84,7 +84,15 @@ EntityPool.prototype.setComponent = function(id, component, value) {
 		);
 	}
 
-	if (typeof value === "undefined" ) {
+	if (!isPrimitive(this._entities[id][component])) {
+		throw new Error(
+			"You can't set a non-primitive type component to a  primitive value. " +
+			"If you must do this, remove the existing component first with " +
+			"EntityPool.prototype.removeComponent(id, component)."
+		);
+	}
+
+	if (typeof value === "undefined") {
 		this.removeComponent(id, component);
 	} else {
 		this._setComponentValue(id, component, value);

--- a/lib/entity-pool.js
+++ b/lib/entity-pool.js
@@ -204,8 +204,8 @@ EntityPool.prototype.load = function(entities) {
 			}
 			var newComponentObject = this.addComponent(id, component);
 			Object.keys(valueToLoad).forEach(function(key) {
-		    newComponentObject[key] = valueToLoad[key];
-		  });
+				newComponentObject[key] = valueToLoad[key];
+			});
 		}.bind(this));
 	}.bind(this));
 	this.fireQueuedCallbacks();

--- a/lib/entity-pool.js
+++ b/lib/entity-pool.js
@@ -28,6 +28,7 @@ EntityPool.prototype.destroy = function(id) {
 		this.removeComponent(id, component);
 	}.bind(this));
 	delete this._entities[id];
+	this._entityPool.free(entity);
 };
 EntityPool.prototype.registerComponent = function(component, factory, size) {
 	this._componentPools[component] = new ObjectPool(factory, size);

--- a/lib/entity-pool.js
+++ b/lib/entity-pool.js
@@ -64,7 +64,7 @@ EntityPool.prototype.addComponent = function(id, component) {
 	}
 
 	var predefinedValue = this._entities[id][component];
-	if (predefinedValue) {
+	if (predefinedValue && !isPrimitive(predefinedValue)) {
 		resetComponent(predefinedValue);
 		return predefinedValue;
 	}

--- a/lib/object-pool-test.js
+++ b/lib/object-pool-test.js
@@ -13,10 +13,10 @@ test("objects get reused after being returned to pool", function(t) {
 
 	var a = pool.alloc();
 	var b = pool.alloc();
-	pool.free(b);
+	pool.free(a);
 	var c = pool.alloc();
 
-	t.equal(b, c);
+	t.equal(a, c);
 });
 
 test("allocated objects match result of factory function", function(t) {

--- a/lib/object-pool-test.js
+++ b/lib/object-pool-test.js
@@ -20,7 +20,7 @@ test("objects get reused after being returned to pool", function(t) {
 });
 
 test("allocated objects match result of factory function", function(t) {
-	t.plan(5);
+	t.plan(1);
 
 	function factory() {
 		return {
@@ -37,11 +37,7 @@ test("allocated objects match result of factory function", function(t) {
 	var allocated = pool.alloc();
 	var factoryResult = factory();
 
-	t.equal(allocated.a, factoryResult.a);
-	t.equal(allocated.b.c, factoryResult.b.c);
-	for (var i = 0; i < 3; i++) {
-		t.equal(allocated.d[i], factoryResult.d[i]);
-	}
+	t.deepEqual(allocated, factoryResult);
 });
 
 test("ObjectPool constructor creates number of objects specified", function(t) {

--- a/lib/object-pool-test.js
+++ b/lib/object-pool-test.js
@@ -12,11 +12,11 @@ test("objects get reused after being returned to pool", function(t) {
 	});
 
 	var a = pool.alloc();
-	var b = pool.alloc();
+	pool.alloc();
 	pool.free(a);
-	var c = pool.alloc();
+	var b = pool.alloc();
 
-	t.equal(a, c);
+	t.equal(a, b);
 });
 
 test("allocated objects match result of factory function", function(t) {
@@ -66,14 +66,14 @@ test("object pool size doubles when limit is exceeded", function(t) {
 	}, size);
 
 	t.equal(pool.size, 2);
-	var o1 = pool.alloc();
+	pool.alloc(); // 1
 	t.equal(pool.size, 2);
-	var o2 = pool.alloc();
+	pool.alloc(); // 2
 	t.equal(pool.size, 2);
-	var o3 = pool.alloc();
+	pool.alloc(); // 3
 	t.equal(pool.size, 4);
-	var o4 = pool.alloc();
+	pool.alloc(); // 4
 	t.equal(pool.size, 4);
-	var o5 = pool.alloc();
+	pool.alloc(); // 5
 	t.equal(pool.size, 8);
 });

--- a/lib/object-pool-test.js
+++ b/lib/object-pool-test.js
@@ -18,3 +18,66 @@ test("objects get reused after being returned to pool", function(t) {
 
 	t.equal(b, c);
 });
+
+test("allocated objects match result of factory function", function(t) {
+	t.plan(5);
+
+	function factory() {
+		return {
+			a: 1,
+			b: {
+				c: "hello world"
+			},
+			d: [3, 2, 1]
+		};
+	}
+
+	var pool = new ObjectPool(factory);
+
+	var allocated = pool.alloc();
+	var factoryResult = factory();
+
+	t.equal(allocated.a, factoryResult.a);
+	t.equal(allocated.b.c, factoryResult.b.c);
+	for (var i = 0; i < 3; i++) {
+		t.equal(allocated.d[i], factoryResult.d[i]);
+	}
+});
+
+test("ObjectPool constructor creates number of objects specified", function(t) {
+	t.plan(4);
+
+	var size = 3;
+
+	var pool = new ObjectPool(function() {
+		return {};
+	}, size);
+	var dead = pool.dead;
+
+	for (var i = 0; i < size; i++) {
+		t.ok(dead[i]);
+	}
+	t.notOk(dead[size], "no more objects created than specified");
+});
+
+test("object pool size doubles when limit is exceeded", function(t) {
+	t.plan(6);
+
+	var size = 2;
+
+	var pool = new ObjectPool(function() {
+		return {};
+	}, size);
+
+	t.equal(pool.size, 2);
+	var o1 = pool.alloc();
+	t.equal(pool.size, 2);
+	var o2 = pool.alloc();
+	t.equal(pool.size, 2);
+	var o3 = pool.alloc();
+	t.equal(pool.size, 4);
+	var o4 = pool.alloc();
+	t.equal(pool.size, 4);
+	var o5 = pool.alloc();
+	t.equal(pool.size, 8);
+});

--- a/lib/object-pool-test.js
+++ b/lib/object-pool-test.js
@@ -1,0 +1,20 @@
+"use strict";
+
+var test = require("tape");
+
+var ObjectPool = require("./object-pool");
+
+test("objects get reused after being returned to pool", function(t) {
+	t.plan(1);
+
+	var pool = new ObjectPool(function() {
+		return {};
+	});
+
+	var a = pool.alloc();
+	var b = pool.alloc();
+	pool.free(b);
+	var c = pool.alloc();
+
+	t.equal(b, c);
+});

--- a/lib/object-pool.js
+++ b/lib/object-pool.js
@@ -1,0 +1,38 @@
+"use strict";
+
+function ObjectPool(factory, size) {
+  if (typeof factory !== "function") {
+    console.error("Pool expects a factory function, got ", factory);
+  }
+  this.factory = factory;
+  this.size = size || 1;
+  this.dead = [];
+
+  for (var i = 0; i < size; i++) {
+    this.dead.push(factory());
+  }
+}
+ObjectPool.prototype.alloc = function() {
+  var factory = this.factory;
+  var obj;
+  if (this.dead.length > 0) {
+    obj = this.dead.pop();
+  } else {
+    obj = factory();
+    /* we assume the number "alive" (not stored here)
+     * must be equal to this.size, so by creating
+     * that many more objects, (including obj above),
+     * we double the size of the pool.
+     */
+    for (var i = 0; i < this.size - 1; i++) {
+      this.dead.push(factory());
+    }
+    this.size *= 2;
+  }
+  return obj;
+};
+ObjectPool.prototype.free = function(obj) {
+  this.dead.push(obj);
+};
+
+module.exports = ObjectPool;

--- a/lib/object-pool.js
+++ b/lib/object-pool.js
@@ -1,38 +1,38 @@
 "use strict";
 
 function ObjectPool(factory, size) {
-  if (typeof factory !== "function") {
-    console.error("Pool expects a factory function, got ", factory);
-  }
-  this.factory = factory;
-  this.size = size || 1;
-  this.dead = [];
+	if (typeof factory !== "function") {
+		console.error("Pool expects a factory function, got ", factory);
+	}
+	this.factory = factory;
+	this.size = size || 1;
+	this.dead = [];
 
-  for (var i = 0; i < size; i++) {
-    this.dead.push(factory());
-  }
+	for (var i = 0; i < size; i++) {
+		this.dead.push(factory());
+	}
 }
 ObjectPool.prototype.alloc = function() {
-  var factory = this.factory;
-  var obj;
-  if (this.dead.length > 0) {
-    obj = this.dead.pop();
-  } else {
-    obj = factory();
-    /* we assume the number "alive" (not stored here)
-     * must be equal to this.size, so by creating
-     * that many more objects, (including obj above),
-     * we double the size of the pool.
-     */
-    for (var i = 0; i < this.size - 1; i++) {
-      this.dead.push(factory());
-    }
-    this.size *= 2;
-  }
-  return obj;
+	var factory = this.factory;
+	var obj;
+	if (this.dead.length > 0) {
+		obj = this.dead.pop();
+	} else {
+		obj = factory();
+		/* we assume the number "alive" (not stored here)
+		 * must be equal to this.size, so by creating
+		 * that many more objects, (including obj above),
+		 * we double the size of the pool.
+		 */
+		for (var i = 0; i < this.size - 1; i++) {
+			this.dead.push(factory());
+		}
+		this.size *= 2;
+	}
+	return obj;
 };
 ObjectPool.prototype.free = function(obj) {
-  this.dead.push(obj);
+	this.dead.push(obj);
 };
 
 module.exports = ObjectPool;

--- a/lib/object-pool.js
+++ b/lib/object-pool.js
@@ -2,7 +2,10 @@
 
 function ObjectPool(factory, size) {
 	if (typeof factory !== "function") {
-		console.error("Pool expects a factory function, got ", factory);
+		throw new TypeError("ObjectPool expects a factory function, got ", factory);
+	}
+	if (size && size < 1 || size === 0) {
+		throw new RangeError("ObjectPool expects an initial size greater than zero");
 	}
 	this.factory = factory;
 	this.size = size || 1;


### PR DESCRIPTION
Object pooling for entities and components implemented to cut down on garbage production/garbage collection.
## Major (breaking) changes
- `EntityPool.prototype.addComponent(id, component)` allocates, adds to the entity with the given `id`, and returns a new component object. If the component already exists on the given entity and that component is not a primitive, the existing object is reset and returned. If a component pool for the given `component` name hasn't been initialized with a factory function (see `EntityPool.registerComponent`), a descriptive error is thrown.
- `EntityPool.prototype.registerComponent(component, factory[, reset, size])` initializes an object pool for components with the given `component` name, by passing the given `factory` function and optional `size` parameter to the `ObjectPool` constructor. Also accepts `reset`, a function which accepts an instance of the component and mutates its properties to an initial state.
- `EntityPool.prototype.set` is now `EntityPool.prototype.setComponent`. It throws an error if the provided `value` is a non-primitive, or if the existing value for this component is a non-primitive (it's much simpler to require users to remove non-primitive component values before adding primitive values to the same component name). Same parameters as before (no return value, like before).
- `EntityPool.prototype.get` is now `EntityPool.prototype.getComponent`. Same parameters and return value as before.
- `EntityPool.prototype.remove` is now `EntityPool.prototype.removeComponent`. The component is reset before being removed. Same parameters as before (no return value, like before).

The "reset" that takes place in `EntityPool.prototype.addComponent` and `EntityPool.prototype.remove` has no effect unless the `reset` function is specified in the `registerComponent` call.
## Test changes
- All tests from before still pass - with the caveat that all invocations of `EntityPool.prototype.set`, `EntityPool.prototype.get` and `EntityPool.prototype.remove` have been renamed appropriately.
- Since there were no prior tests setting non-primitive components, no relevant tests were there to break. However, new tests have been added for object components.
## `ObjectPool`
- Doesn't break anything on its own, since it's only depended upon by the `EntityPool` class (for now, anyway).
- `ObjectPool(factory[, size])` constructor accepts a `factory` function which generates newly allocated objects, and an optional `size` parameter which is the initial number of objects to be allocated.
- `ObjectPool.prototype.alloc` takes no parameters and returns an already-free object by default. If no objects are free, the object pool generates `size` new objects, after which the value of `size` is doubled (to match the new number of "dead" and "alive" objects combined).
- `ObjectPool.prototype.free` takes an already-allocated object and pushes it to the "dead" stack, to be used again.
